### PR TITLE
Prepare to use with Sidekiq 6+

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,7 @@ GEM
       tzinfo (~> 1.1)
     ast (2.4.2)
     concurrent-ruby (1.1.10)
+    connection_pool (2.4.1)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dotenv (2.7.6)
@@ -28,6 +29,8 @@ GEM
     rainbow (3.1.1)
     rake (13.0.6)
     redis (4.2.5)
+    redis-client (0.15.0)
+      connection_pool
     regexp_parser (2.5.0)
     rexml (3.2.5)
     rspec (3.11.0)
@@ -84,6 +87,7 @@ DEPENDENCIES
   http_health_check!
   rake (~> 13.0)
   redis (~> 4.2.5)
+  redis-client (~> 0.15.0)
   rspec (~> 3.2)
   rspec_junit_formatter
   rubocop (~> 0.81)

--- a/http_health_check.gemspec
+++ b/http_health_check.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'activesupport', '~> 5.0'
   spec.add_development_dependency 'dotenv', '~> 2.7.6'
   spec.add_development_dependency 'redis', '~> 4.2.5'
+  spec.add_development_dependency 'redis-client', '~> 0.15.0'
   spec.add_development_dependency 'rspec', '~> 3.2'
   spec.add_development_dependency 'rubocop', '~> 0.81'
   spec.add_development_dependency 'thor', '>= 0.20'

--- a/lib/http_health_check/probes/sidekiq.rb
+++ b/lib/http_health_check/probes/sidekiq.rb
@@ -14,7 +14,7 @@ module HttpHealthCheck
 
       def probe(_env)
         @sidekiq_module.redis do |conn|
-          conn.setex(meta[:redis_key], TTL_SEC, MAGIC_NUMBER)
+          conn.call('SET', meta[:redis_key], MAGIC_NUMBER, 'EX', TTL_SEC)
           probe_ok
         end
       end

--- a/spec/http_health_check/probes/sidekiq_spec.rb
+++ b/spec/http_health_check/probes/sidekiq_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'redis'
+require 'redis-client'
 module Sidekiq; end
 require_relative '../../../lib/http_health_check/probes/sidekiq'
 
@@ -20,28 +21,64 @@ describe HttpHealthCheck::Probes::Sidekiq do
 
   let(:sidekiq) { fake_sidekiq.new(redis) }
 
-  context 'when redis is available', redis: true do
-    let(:redis) { Redis.new(url: ENV.fetch('REDIS_URL', 'redis://127.0.0.1:6379/1')) }
+  shared_context :connected_redis do
+    let(:redis_url) { ENV.fetch('REDIS_URL', 'redis://127.0.0.1:6379/1') }
+  end
 
+  shared_context :disconnected_redis do
+    let(:redis_url) { 'redis://127.0.0.1:63799/999' }
+  end
+
+  shared_examples :positive_probe do
     it 'writes temporary key into redis and returns positive result' do
       result = subject.call(nil)
       expect(result).to be_ok
 
-      expect(redis.get(result.meta[:redis_key]).to_i).to eq(described_class::MAGIC_NUMBER)
+      expect(redis.call('GET', result.meta[:redis_key]).to_i).to eq(described_class::MAGIC_NUMBER)
 
-      ttl = redis.ttl(result.meta[:redis_key]).to_i
+      ttl = redis.call('TTL', result.meta[:redis_key]).to_i
       expect(ttl).to be <= described_class::TTL_SEC
       expect(ttl).to be > 0
     end
   end
 
-  context 'when redis is not available', redis: true do
-    let(:redis) { Redis.new(url: 'redis://127.0.0.1:63799/999') }
-
+  shared_examples :negative_probe do
     it 'returns an error' do
       result = subject.call(nil)
       expect(result).not_to be_ok
-      expect(result.meta[:error_class]).to eq('Redis::CannotConnectError')
+      expect(result.meta[:error_class].split('::').last).to eq('CannotConnectError')
+    end
+  end
+
+  context 'with redis' do
+    let(:redis) { Redis.new(url: redis_url) }
+
+    context 'when server is available', redis: true do
+      include_context :connected_redis
+
+      it_behaves_like :positive_probe
+    end
+
+    context 'when server is not available', redis: true do
+      include_context :disconnected_redis
+
+      it_behaves_like :negative_probe
+    end
+  end
+
+  context 'with redis-client' do
+    let(:redis) { RedisClient.new(url: redis_url) }
+
+    context 'when server is available', redis: true do
+      include_context :connected_redis
+
+      it_behaves_like :positive_probe
+    end
+
+    context 'when redis-client is not available', redis: true do
+      include_context :disconnected_redis
+
+      it_behaves_like :negative_probe
     end
   end
 end


### PR DESCRIPTION
[Deprecated `SETEX` redis command](https://redis.io/commands/setex/) is now removed from Sidekiq probe.
Support for [RedisClient API](https://github.com/sidekiq/sidekiq/blob/main/docs/7.0-Upgrade.md#redis-client) has been added.